### PR TITLE
Fix undefined variable error

### DIFF
--- a/terminal.php
+++ b/terminal.php
@@ -17,6 +17,7 @@
 	}
 	
 	$toggling_persist = FALSE;
+	$toggling_current_persist_command = FALSE;
 	
 	if (isset($_POST['persist_command_id']) AND is_numeric($_POST['persist_command_id'])) {
 		$toggling_persist = TRUE;


### PR DESCRIPTION
Initialize $toggling_current_persist_command variable to fix the following error:
Notice: Undefined variable: toggling_current_persist_command in /docker/code/__terminal/terminal.php on line 74
